### PR TITLE
docs(k3s): add .env.k8s.example secret template for prod/staging

### DIFF
--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -1,9 +1,9 @@
 # k8s Secret `qkjudge-secrets` に投入する **secret 専用** env テンプレート。
 # `.env.example` (compose 用フル env) とは別物。非 secret な key はここに書かず
 # ConfigMap (`qkjudge-config`) 側で管理する:
-#   - 共通 env (MARIADB_DATABASE / MARIADB_USER / MARIADB_USERNAME /
-#     MARIADB_HOSTNAME / COOKIE_SECURE) は deploy/k3s/base/kustomization.yaml
-#     の configMapGenerator。
+#   - 共通 env (QKJUDGE_ADDRESS / MARIADB_HOSTNAME / DB_PORT / MARIADB_DATABASE /
+#     MARIADB_USER / MARIADB_USERNAME / COOKIE_SECURE) は
+#     deploy/k3s/base/kustomization.yaml の configMapGenerator。
 #   - 環境別 env (CORS_ALLOW_ORIGIN) は deploy/k3s/overlays/{prod,staging}/
 #     kustomization.yaml で behavior: merge により足される。
 #

--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -5,9 +5,9 @@
 # の configMapGenerator 参照)。
 #
 # 運用:
-#   cp .env.k8s.example .env.k8s.prod
-#   cp .env.k8s.example .env.k8s.staging
-#   chmod 600 .env.k8s.prod .env.k8s.staging   # ファイル名は .gitignore の .env.* に乗る
+#   cp -n .env.k8s.example .env.k8s.prod        # -n は既存ファイルを上書きしない
+#   cp -n .env.k8s.example .env.k8s.staging     # (再実行で埋めた値を消さないため)
+#   chmod 600 .env.k8s.prod .env.k8s.staging    # ファイル名は .gitignore の .env.* に乗る
 #   kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
 #     --from-env-file=.env.k8s.prod --dry-run=client -o yaml | kubectl apply -f -
 #

--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -1,0 +1,26 @@
+# k8s Secret `qkjudge-secrets` に投入する **secret 専用** env テンプレート。
+# `.env.example` (compose 用フル env) とは別物。重複 key は ConfigMap 側で
+# 管理しているのでこちらに書かない (MARIADB_DATABASE / MARIADB_USER /
+# CORS_ALLOW_ORIGIN / COOKIE_SECURE 等は deploy/k3s/base/kustomization.yaml
+# の configMapGenerator 参照)。
+#
+# 運用:
+#   cp .env.k8s.example .env.k8s.prod      # staging も同様、値は別に生成すること
+#   chmod 600 .env.k8s.{prod,staging}      # ファイル名は .gitignore の .env.* に乗る
+#   kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
+#     --from-env-file=.env.k8s.prod --dry-run=client -o yaml | kubectl apply -f -
+#
+# 値の生成:
+#   MARIADB_ROOT_PASSWORD / MARIADB_PASSWORD : openssl rand -base64 24 (prod/staging で別)
+#   SESSION_KEY                              : openssl rand -hex 32   (64 hex 固定)
+#   GITHUB_WEBHOOK_TOKEN                     : openssl rand -hex 32   (prod/staging で別、
+#                                              GitHub Webhook 側にも同値を登録)
+#   COMPILER_API_CLIENT_ID / _SECRET         : JDoodle dashboard から取得
+#                                              (現状は prod/staging で同じ key を共有して quota も共有)
+
+MARIADB_ROOT_PASSWORD=
+MARIADB_PASSWORD=
+SESSION_KEY=
+GITHUB_WEBHOOK_TOKEN=
+COMPILER_API_CLIENT_ID=
+COMPILER_API_CLIENT_SECRET=

--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -5,8 +5,9 @@
 # の configMapGenerator 参照)。
 #
 # 運用:
-#   cp .env.k8s.example .env.k8s.prod      # staging も同様、値は別に生成すること
-#   chmod 600 .env.k8s.{prod,staging}      # ファイル名は .gitignore の .env.* に乗る
+#   cp .env.k8s.example .env.k8s.prod
+#   cp .env.k8s.example .env.k8s.staging
+#   chmod 600 .env.k8s.prod .env.k8s.staging   # ファイル名は .gitignore の .env.* に乗る
 #   kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
 #     --from-env-file=.env.k8s.prod --dry-run=client -o yaml | kubectl apply -f -
 #

--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -1,8 +1,11 @@
 # k8s Secret `qkjudge-secrets` に投入する **secret 専用** env テンプレート。
-# `.env.example` (compose 用フル env) とは別物。重複 key は ConfigMap 側で
-# 管理しているのでこちらに書かない (MARIADB_DATABASE / MARIADB_USER /
-# CORS_ALLOW_ORIGIN / COOKIE_SECURE 等は deploy/k3s/base/kustomization.yaml
-# の configMapGenerator 参照)。
+# `.env.example` (compose 用フル env) とは別物。非 secret な key はここに書かず
+# ConfigMap (`qkjudge-env`) 側で管理する:
+#   - 共通 env (MARIADB_DATABASE / MARIADB_USER / MARIADB_USERNAME /
+#     MARIADB_HOSTNAME / COOKIE_SECURE) は deploy/k3s/base/kustomization.yaml
+#     の configMapGenerator。
+#   - 環境別 env (CORS_ALLOW_ORIGIN) は deploy/k3s/overlays/{prod,staging}/
+#     kustomization.yaml で behavior: merge により足される。
 #
 # 運用:
 #   cp -n .env.k8s.example .env.k8s.prod        # -n は既存ファイルを上書きしない

--- a/.env.k8s.example
+++ b/.env.k8s.example
@@ -1,6 +1,6 @@
 # k8s Secret `qkjudge-secrets` に投入する **secret 専用** env テンプレート。
 # `.env.example` (compose 用フル env) とは別物。非 secret な key はここに書かず
-# ConfigMap (`qkjudge-env`) 側で管理する:
+# ConfigMap (`qkjudge-config`) 側で管理する:
 #   - 共通 env (MARIADB_DATABASE / MARIADB_USER / MARIADB_USERNAME /
 #     MARIADB_HOSTNAME / COOKIE_SECURE) は deploy/k3s/base/kustomization.yaml
 #     の configMapGenerator。

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .env
 .env.*
 !.env.example
+!.env.k8s.example
 
 env.sh
 env.showcase.json

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -66,8 +66,9 @@ kubectl create namespace qkjudge-staging --dry-run=client -o yaml | kubectl appl
 `.env.k8s.example` のコメントに集約)。
 
 ```sh
-cp .env.k8s.example .env.k8s.prod
-cp .env.k8s.example .env.k8s.staging
+# -n は既存ファイルを上書きしない (再実行で値を消さないため)。
+cp -n .env.k8s.example .env.k8s.prod
+cp -n .env.k8s.example .env.k8s.staging
 chmod 600 .env.k8s.prod .env.k8s.staging
 # .env.k8s.prod / .env.k8s.staging を編集して値を埋める (生成コマンドはテンプレ参照)。
 # prod / staging で値は別 (JDoodle 以外)。

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -67,8 +67,10 @@ kubectl create namespace qkjudge-staging --dry-run=client -o yaml | kubectl appl
 
 ```sh
 cp .env.k8s.example .env.k8s.prod
-chmod 600 .env.k8s.prod
-# .env.k8s.prod を編集して値を埋める (生成コマンドはテンプレ参照)。staging も同様 (値は別)。
+cp .env.k8s.example .env.k8s.staging
+chmod 600 .env.k8s.prod .env.k8s.staging
+# .env.k8s.prod / .env.k8s.staging を編集して値を埋める (生成コマンドはテンプレ参照)。
+# prod / staging で値は別 (JDoodle 以外)。
 
 kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
   --from-env-file=.env.k8s.prod \

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -61,9 +61,25 @@ kubectl create namespace qkjudge-staging --dry-run=client -o yaml | kubectl appl
 
 ### 2. アプリ secret (`qkjudge-secrets`)
 
-各 namespace に投入する。`SESSION_KEY` は 64 hex (32 byte)。
+各 namespace に投入する。`.env.k8s.example` をテンプレートにして `.env.k8s.{prod,staging}`
+を作り、`--from-env-file` で流し込む方式が一番楽 (値の生成コマンド・key 一覧・運用メモも
+`.env.k8s.example` のコメントに集約)。
 
-同名 Secret が既にあっても再実行できるよう、冪等な `--dry-run=client | apply` 形式にする。
+```sh
+cp .env.k8s.example .env.k8s.prod
+chmod 600 .env.k8s.prod
+# .env.k8s.prod を編集して値を埋める (生成コマンドはテンプレ参照)。staging も同様 (値は別)。
+
+kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
+  --from-env-file=.env.k8s.prod \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n qkjudge-staging create secret generic qkjudge-secrets \
+  --from-env-file=.env.k8s.staging \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+`--from-literal` 版 (ad-hoc にその場で投入したい場合):
 
 ```sh
 kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
@@ -76,7 +92,8 @@ kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-staging も同様 (`-n qkjudge-staging`、値は別に発番推奨)。
+`.env.k8s.{prod,staging}` は `.gitignore` の `.env.*` パターンで自動的に追跡対象外。
+長期保管はパスワードマネージャ等で別途行う (将来 Sealed Secrets / sops 移行を想定)。
 
 > キー名は `src/main.rs` / MariaDB イメージが読む env 名と一致させること
 > (`MARIADB_PASSWORD` はアプリと DB で共有、`MARIADB_ROOT_PASSWORD` は DB と backup CronJob が使う)。

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -61,9 +61,9 @@ kubectl create namespace qkjudge-staging --dry-run=client -o yaml | kubectl appl
 
 ### 2. アプリ secret (`qkjudge-secrets`)
 
-各 namespace に投入する。`.env.k8s.example` をテンプレートにして `.env.k8s.{prod,staging}`
-を作り、`--from-env-file` で流し込む方式が一番楽 (値の生成コマンド・key 一覧・運用メモも
-`.env.k8s.example` のコメントに集約)。
+各 namespace に投入する。`.env.k8s.example` をテンプレートにして
+`.env.k8s.prod` / `.env.k8s.staging` を作り、`--from-env-file` で流し込む方式が
+一番楽 (値の生成コマンド・key 一覧・運用メモも `.env.k8s.example` のコメントに集約)。
 
 ```sh
 # -n は既存ファイルを上書きしない (再実行で値を消さないため)。
@@ -95,8 +95,9 @@ kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-`.env.k8s.{prod,staging}` は `.gitignore` の `.env.*` パターンで自動的に追跡対象外。
-長期保管はパスワードマネージャ等で別途行う (将来 Sealed Secrets / sops 移行を想定)。
+`.env.k8s.prod` / `.env.k8s.staging` は `.gitignore` の `.env.*` パターンで
+自動的に追跡対象外。長期保管はパスワードマネージャ等で別途行う
+(将来 Sealed Secrets / sops 移行を想定)。
 
 > キー名は `src/main.rs` / MariaDB イメージが読む env 名と一致させること
 > (`MARIADB_PASSWORD` はアプリと DB で共有、`MARIADB_ROOT_PASSWORD` は DB と backup CronJob が使う)。


### PR DESCRIPTION
## 概要

k8s Secret `qkjudge-secrets` 投入時に毎回 `--from-literal` を 6 つ並べるのが
だるいので、env-file 経由で流す方式を docs 化する。`migrate/leafeon` の
live follow-up (TASK-003/004) で実機にコマンドを貼る前のお膳立て。

## 変更点

- **`.env.k8s.example`** を新規追加。Secret に入れる 6 key を列挙し、値の生成コマンドや
  prod/staging で別値にする / 共有する key の運用メモまでコメントで集約する。
  - `MARIADB_ROOT_PASSWORD` / `MARIADB_PASSWORD`: `openssl rand -base64 24` (prod/staging で別)
  - `SESSION_KEY`: `openssl rand -hex 32` (64 hex 固定、別)
  - `GITHUB_WEBHOOK_TOKEN`: `openssl rand -hex 32` (prod/staging で別、GitHub Webhook 側にも同値登録)
  - `COMPILER_API_CLIENT_ID` / `_SECRET`: JDoodle dashboard (現状は prod/staging で同じ key を共有)
- **`.gitignore`** に `!.env.k8s.example` を追加。既存の `.env.*` パターンで弾かれないようにする
  (compose 用 `.env.example` と並列、`*.example` 全許可みたいな広いパターンは避ける)。
- **`deploy/k3s/README.md`** の secret 投入セクションに `--from-env-file` 版を追記
  (既存 `--from-literal` 版は ad-hoc 用に残す)。

## 運用想定

```sh
cp .env.k8s.example .env.k8s.prod
chmod 600 .env.k8s.prod
# 値を埋める (生成コマンドはテンプレのコメント参照)。staging も同様 (値は別)。
kubectl -n qkjudge-prod create secret generic qkjudge-secrets \
  --from-env-file=.env.k8s.prod --dry-run=client -o yaml | kubectl apply -f -
```

`.env.k8s.{prod,staging}` は `.gitignore` の `.env.*` パターンで自動的に
追跡対象外。長期保管はパスワードマネージャ等で別途 (将来 Sealed Secrets / sops 移行を想定)。

## 検証

- `gitleaks --staged` no leaks。
- `git check-ignore -v .env.k8s.example` → `!.env.k8s.example` で追跡対象に戻ることを確認。
- `git check-ignore -v .env.k8s.prod` → `.env.*` で除外されることを確認 (ファイル名で実値が漏れない)。