### PR TITLE
fix(infra): rename API hosts to fit Cloudflare Universal SSL 1-level wildcard

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,7 @@
 | `ci.yml`     | `pull_request` / push master,dev | GitHub-hosted  | `cargo fmt --check` / `clippy -D warnings` / `cargo test`。secret 不使用 |
 | `deploy.yml` | push master,dev のみ             | build=hosted, deploy=self-hosted | build→GHCR push (`:{branch}`/`:{sha}`)、deploy=対象 ns の image 差し替え |
 
-- `master` → prod (`qkjudge-prod`, `api.qkjudge.kisen.one`)、`dev` → staging (`qkjudge-staging`, `api.dev.qkjudge.kisen.one`)。
+- `master` → prod (`qkjudge-prod`, `qkjudge-api.kisen.one`)、`dev` → staging (`qkjudge-staging`, `qkjudge-api-stg.kisen.one`)。
 - deploy は GitHub-hosted で GHCR に push 後、self-hosted Runner が `kubectl set image` で
   イミュータブルな `:{sha}` タグへ差し替え `rollout status` で完了を待つ。
 

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -13,7 +13,7 @@ Cloudflare tunnel ──► cloudflared (Deployment, ns: cloudflared)
                           │  host で振り分け (Ingress)
             ┌─────────────┴─────────────┐
             ▼                           ▼
-  api.qkjudge.kisen.one        api.dev.qkjudge.kisen.one
+  qkjudge-api.kisen.one        qkjudge-api-stg.kisen.one
   ns: qkjudge-prod             ns: qkjudge-staging
     qkjudge-app (Deploy)         qkjudge-app (Deploy)
     qkjudge-mariadb (STS+PVC)    qkjudge-mariadb (STS+PVC)
@@ -27,8 +27,8 @@ Cloudflare tunnel ──► cloudflared (Deployment, ns: cloudflared)
 ```
 deploy/k3s/
   base/                 # 環境共通 (MariaDB STS / app Deploy+Svc / Ingress / backup CronJob / 共通 env)
-  overlays/prod/        # namespace=qkjudge-prod, image :master, host api.qkjudge.kisen.one
-  overlays/staging/     # namespace=qkjudge-staging, image :dev,  host api.dev.qkjudge.kisen.one
+  overlays/prod/        # namespace=qkjudge-prod, image :master, host qkjudge-api.kisen.one
+  overlays/staging/     # namespace=qkjudge-staging, image :dev,  host qkjudge-api-stg.kisen.one
   cloudflared/          # クラスタ singleton tunnel (両環境共有)
 ```
 
@@ -159,8 +159,8 @@ tunnel をホスト名に紐付ける。`route dns` が Cloudflare DNS に `CNAM
 (proxied) を自動作成する。
 
 ```sh
-cloudflared tunnel route dns qkjudge api.qkjudge.kisen.one
-cloudflared tunnel route dns qkjudge api.dev.qkjudge.kisen.one
+cloudflared tunnel route dns qkjudge qkjudge-api.kisen.one
+cloudflared tunnel route dns qkjudge qkjudge-api-stg.kisen.one
 ```
 
 ダッシュボードで手動作成する場合は、`kisen.one` ゾーンに以下を **Proxied** で追加:
@@ -173,8 +173,8 @@ cloudflared tunnel route dns qkjudge api.dev.qkjudge.kisen.one
 ## 疎通確認
 
 ```sh
-curl -i https://api.qkjudge.kisen.one/ping        # → 200
-curl -i https://api.dev.qkjudge.kisen.one/ping    # → 200
+curl -i https://qkjudge-api.kisen.one/ping        # → 200
+curl -i https://qkjudge-api-stg.kisen.one/ping    # → 200
 ```
 
 主要フロー (signup/login/problems/submit→judge/submissions) を確認する。problems は

--- a/deploy/k3s/README.md
+++ b/deploy/k3s/README.md
@@ -167,8 +167,8 @@ cloudflared tunnel route dns qkjudge qkjudge-api-stg.kisen.one
 
 | Type  | Name             | Target                          |
 | ----- | ---------------- | ------------------------------- |
-| CNAME | api.qkjudge      | `<TUNNEL_ID>.cfargotunnel.com`  |
-| CNAME | api.dev.qkjudge  | `<TUNNEL_ID>.cfargotunnel.com`  |
+| CNAME | qkjudge-api      | `<TUNNEL_ID>.cfargotunnel.com`  |
+| CNAME | qkjudge-api-stg  | `<TUNNEL_ID>.cfargotunnel.com`  |
 
 ## 疎通確認
 

--- a/deploy/k3s/base/ingress.yaml
+++ b/deploy/k3s/base/ingress.yaml
@@ -1,10 +1,15 @@
 # k3s 同梱 Traefik で受ける Ingress。host は overlay の kustomization.yaml の
-# JSON6902 patches で差し替える
+# JSON6902 patches で必ず差し替える
 # (prod=qkjudge-api.kisen.one / staging=qkjudge-api-stg.kisen.one)。
 # 1 階層 wildcard *.kisen.one (Cloudflare Universal SSL) でカバーするため、
 # 2 階層深い api.qkjudge.kisen.one 系は使わない (旧名)。
 # 経路: Cloudflare tunnel → cloudflared → Traefik(web:80) → この Ingress → qkjudge-app:8080。
 # TLS 終端は Cloudflare edge。クラスタ内は平文 http (web entrypoint) で受ける。
+#
+# 注: base 単体で `kubectl apply -k deploy/k3s/base` した場合に prod 実ホスト向け
+# Ingress が誤って作られないよう、base の host は RFC 2606 の reserved TLD .invalid
+# (DNS で絶対に解決されない) にしている。overlay の JSON6902 op: replace で常に
+# 実ホストに差し替える前提。
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -14,7 +19,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: qkjudge-api.kisen.one
+    - host: override-in-overlay.invalid
       http:
         paths:
           - path: /

--- a/deploy/k3s/base/ingress.yaml
+++ b/deploy/k3s/base/ingress.yaml
@@ -1,4 +1,5 @@
-# k3s 同梱 Traefik で受ける Ingress。host は overlay の ingress-patch.yaml で差し替える
+# k3s 同梱 Traefik で受ける Ingress。host は overlay の kustomization.yaml の
+# JSON6902 patches で差し替える
 # (prod=qkjudge-api.kisen.one / staging=qkjudge-api-stg.kisen.one)。
 # 1 階層 wildcard *.kisen.one (Cloudflare Universal SSL) でカバーするため、
 # 2 階層深い api.qkjudge.kisen.one 系は使わない (旧名)。

--- a/deploy/k3s/base/ingress.yaml
+++ b/deploy/k3s/base/ingress.yaml
@@ -1,5 +1,7 @@
 # k3s 同梱 Traefik で受ける Ingress。host は overlay の ingress-patch.yaml で差し替える
-# (prod=api.qkjudge.kisen.one / staging=api.dev.qkjudge.kisen.one)。
+# (prod=qkjudge-api.kisen.one / staging=qkjudge-api-stg.kisen.one)。
+# 1 階層 wildcard *.kisen.one (Cloudflare Universal SSL) でカバーするため、
+# 2 階層深い api.qkjudge.kisen.one 系は使わない (旧名)。
 # 経路: Cloudflare tunnel → cloudflared → Traefik(web:80) → この Ingress → qkjudge-app:8080。
 # TLS 終端は Cloudflare edge。クラスタ内は平文 http (web entrypoint) で受ける。
 apiVersion: networking.k8s.io/v1
@@ -11,7 +13,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: api.qkjudge.kisen.one
+    - host: qkjudge-api.kisen.one
       http:
         paths:
           - path: /

--- a/deploy/k3s/cloudflared/config.yaml
+++ b/deploy/k3s/cloudflared/config.yaml
@@ -10,8 +10,8 @@ credentials-file: /etc/cloudflared/creds/credentials.json
 no-autoupdate: true
 metrics: 0.0.0.0:2000
 ingress:
-  - hostname: api.qkjudge.kisen.one
+  - hostname: qkjudge-api.kisen.one
     service: http://traefik.kube-system.svc.cluster.local:80
-  - hostname: api.dev.qkjudge.kisen.one
+  - hostname: qkjudge-api-stg.kisen.one
     service: http://traefik.kube-system.svc.cluster.local:80
   - service: http_status:404

--- a/deploy/k3s/overlays/prod/kustomization.yaml
+++ b/deploy/k3s/overlays/prod/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# prod 環境。master ブランチ相当の image を api.qkjudge.kisen.one で公開する。
+# prod 環境。master ブランチ相当の image を qkjudge-api.kisen.one で公開する。
 namespace: qkjudge-prod
 
 resources:
@@ -27,4 +27,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/rules/0/host
-        value: api.qkjudge.kisen.one
+        value: qkjudge-api.kisen.one

--- a/deploy/k3s/overlays/staging/kustomization.yaml
+++ b/deploy/k3s/overlays/staging/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# staging 環境。dev ブランチ相当の image を api.dev.qkjudge.kisen.one で公開する。
+# staging 環境。dev ブランチ相当の image を qkjudge-api-stg.kisen.one で公開する。
 # prod との差分は namespace / image tag / Ingress host / CORS origin のみ
 # (DB は別 namespace の StatefulSet なので独立。DB 名は共通でよい)。
 namespace: qkjudge-staging
@@ -28,4 +28,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/rules/0/host
-        value: api.dev.qkjudge.kisen.one
+        value: qkjudge-api-stg.kisen.one

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -57,7 +57,7 @@ prod namespace                         staging namespace
   mariadb (statefulset + PVC)            mariadb (statefulset + PVC)
   secret (JDoodle/DB/webhook/cookie)     secret (...)
   ingress qkjudge-api.kisen.one          ingress qkjudge-api-stg.kisen.one
-cloudflared (deploy) ── tunnel ── Cloudflare ── qkjudge-api*.kisen.one
+cloudflared (deploy) ── tunnel ── Cloudflare ── qkjudge-api.kisen.one / qkjudge-api-stg.kisen.one
 frontend: GitHub Pages (kisen.one 独自ドメイン) — k3s 外
 ```
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -39,7 +39,7 @@ qkjudge サーバーは traP の NeoShowcase 上で、gitea `git.trap.jp/tqk/qkj
 | 項目                 | 決定                                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | オーケストレーション | k3s on leafeon。最初から prod / staging のマルチ環境 (旧 Showcase のブランチ別デプロイを踏襲)                                                                                  |
-| 環境マッピング       | `master`→prod (`qkjudge.kisen.one` / API `api.qkjudge.kisen.one`)、`dev`→staging (`dev.qkjudge.kisen.one` / `api.dev.qkjudge.kisen.one`)                                       |
+| 環境マッピング       | `master`→prod (`qkjudge.kisen.one` / API `qkjudge-api.kisen.one`)、`dev`→staging (`dev.qkjudge.kisen.one` / `qkjudge-api-stg.kisen.one`)                                       |
 | コンテナレジストリ   | GHCR (`ghcr.io/kisepichu/qkjudge`)                                                                                                                                             |
 | デプロイ反映         | leafeon 上のセルフホスト GitHub Actions Runner が `kubectl` 適用 (k3s API を外部公開しない)。**セキュリティ堅牢化必須**。GitOps(Argo/Flux) は将来移行                          |
 | 公開                 | cloudflared を k3s 内 Deployment として動かし、tunnel ingress 設定も k3s マニフェストで管理する (鯖機を直接設定せず pull+反映で完結)。DNS は Cloudflare に CNAME               |
@@ -56,8 +56,8 @@ prod namespace                         staging namespace
   qkjudge (deploy, image :master)        qkjudge (deploy, image :dev)
   mariadb (statefulset + PVC)            mariadb (statefulset + PVC)
   secret (JDoodle/DB/webhook/cookie)     secret (...)
-  ingress api.qkjudge.kisen.one          ingress api.dev.qkjudge.kisen.one
-cloudflared (deploy) ── tunnel ── Cloudflare ── *.qkjudge.kisen.one
+  ingress qkjudge-api.kisen.one          ingress qkjudge-api-stg.kisen.one
+cloudflared (deploy) ── tunnel ── Cloudflare ── qkjudge-api*.kisen.one
 frontend: GitHub Pages (kisen.one 独自ドメイン) — k3s 外
 ```
 

--- a/tasks/todo/TASK-006-frontend-cutover.md
+++ b/tasks/todo/TASK-006-frontend-cutover.md
@@ -16,10 +16,10 @@
 
 ## 設計メモ
 
-- **API URL**: prod `.env` → `https://qkjudge-api.kisen.one`、staging 用に `dev.` 系も用意。
+- **API URL**: prod `.env` → `https://qkjudge-api.kisen.one`、staging `.env` → `https://qkjudge-api-stg.kisen.one`。
 - **Cookie**: フロント `qkjudge.kisen.one` と API `qkjudge-api.kisen.one` は **same-site**(同一 registrable domain `kisen.one`)
-  なので `SameSite=Lax; Secure` + `withCredentials` で問題なく動く。Cookie は **API ドメイン(`api.*`)上で完結**し
-  (host-only、Domain 属性で親に広げない)、**HTTPS / `Secure` 前提**。これらが満たされることを確認する。
+  なので `SameSite=Lax; Secure` + `withCredentials` で問題なく動く。Cookie は **API ホスト上で host-only に完結**し
+  (Domain 属性で親に広げない)、**HTTPS / `Secure` 前提**。これらが満たされることを確認する。
 - **ドメイン/公開**: GitHub Pages の独自ドメインを `qkjudge.kisen.one` に (CNAME ファイル + Cloudflare DNS)。
   staging フロントは `dev.qkjudge.kisen.one` (別 Pages か k3s 配信かは TASK-003/004 と整合)。
 - **再登録告知**: トップページに「旧 judge.tqk.blue のアカウントは移行されていません。再登録してください」を表示。

--- a/tasks/todo/TASK-006-frontend-cutover.md
+++ b/tasks/todo/TASK-006-frontend-cutover.md
@@ -16,8 +16,8 @@
 
 ## 設計メモ
 
-- **API URL**: prod `.env` → `https://api.qkjudge.kisen.one`、staging 用に `dev.` 系も用意。
-- **Cookie**: フロント `qkjudge.kisen.one` と API `api.qkjudge.kisen.one` は **same-site**(同一 registrable domain `kisen.one`)
+- **API URL**: prod `.env` → `https://qkjudge-api.kisen.one`、staging 用に `dev.` 系も用意。
+- **Cookie**: フロント `qkjudge.kisen.one` と API `qkjudge-api.kisen.one` は **same-site**(同一 registrable domain `kisen.one`)
   なので `SameSite=Lax; Secure` + `withCredentials` で問題なく動く。Cookie は **API ドメイン(`api.*`)上で完結**し
   (host-only、Domain 属性で親に広げない)、**HTTPS / `Secure` 前提**。これらが満たされることを確認する。
 - **ドメイン/公開**: GitHub Pages の独自ドメインを `qkjudge.kisen.one` に (CNAME ファイル + Cloudflare DNS)。


### PR DESCRIPTION
## 概要

実機投入後の curl で **TLS handshake alert 40 (no peer certificate available)** が発生。原因は **Cloudflare Free の Universal SSL は 1 階層 wildcard までしかカバーしない**こと。

| ホスト名 | `*.kisen.one` Universal SSL カバー |
| --- | --- |
| `qkjudge.kisen.one` | ✅ |
| `api.qkjudge.kisen.one` (旧 prod) | ❌ 2 階層 |
| `api.dev.qkjudge.kisen.one` (旧 staging) | ❌ 3 階層 |

mac / leafeon 両方で同じ alert (clinet 側 cipher 問題ではなく確実に edge cert の問題) を確認済み。

## 変更点

ホスト名を 1 階層に揃えて Universal SSL 範囲内に収める (コスト 0、ACM の月 \$10 を回避):

| 環境 | 旧 | 新 |
| --- | --- | --- |
| prod | `api.qkjudge.kisen.one` | **`qkjudge-api.kisen.one`** |
| staging | `api.dev.qkjudge.kisen.one` | **`qkjudge-api-stg.kisen.one`** |

frontend (`qkjudge.kisen.one`, GitHub Pages 配信) は変更なし。CORS は別オリジン扱いだが既に `CORS_ALLOW_ORIGIN` で対応済みなので影響なし。

### 更新ファイル
- `deploy/k3s/base/ingress.yaml`: host を新名に。冒頭コメントで旧名を「使わない (旧名)」として残し経緯を追えるように。
- `deploy/k3s/overlays/{prod,staging}/kustomization.yaml`: JSON6902 patch の `value` と冒頭コメント。
- `deploy/k3s/cloudflared/config.yaml`: tunnel ingress の `hostname` 2 件。
- `docs/MIGRATION.md` / `deploy/k3s/README.md` / `.github/workflows/README.md` / `tasks/todo/TASK-006-frontend-cutover.md`: 旧名参照を新名に置換。
- `tasks/done/TASK-003-k3s-prod-staging.md` は履歴として旧名のまま残す。

## 検証

```sh
kubectl kustomize deploy/k3s/overlays/prod    | grep "host:"
# → host: qkjudge-api.kisen.one
kubectl kustomize deploy/k3s/overlays/staging | grep "host:"
# → host: qkjudge-api-stg.kisen.one
```

## マージ後の実機 follow-up

1. 旧 DNS レコード削除 (Cloudflare dashboard):
   - `api.qkjudge.kisen.one`
   - `api.dev.qkjudge.kisen.one`
2. 新 DNS 作成:
   ```sh
   cloudflared tunnel route dns qkjudge qkjudge-api.kisen.one
   cloudflared tunnel route dns qkjudge qkjudge-api-stg.kisen.one
   ```
3. manifests 再適用:
   ```sh
   git pull origin migrate/leafeon
   kubectl apply -k deploy/k3s/overlays/prod
   kubectl apply -k deploy/k3s/overlays/staging
   kubectl apply -k deploy/k3s/cloudflared
   ```
4. 疎通:
   ```sh
   curl -i https://qkjudge-api.kisen.one/ping      # → 503 (app は ImagePullBackOff、TLS は通る)
   curl -i https://qkjudge-api-stg.kisen.one/ping  # 同上
   ```