### PR TITLE
fix(T005): include migration/legacy-snapshot in Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN mkdir src && echo 'fn main() {}' > src/main.rs \
     && rm -rf src
 
 # 本体ビルド。sqlx-data.json があるため実 DB 不要 (SQLX_OFFLINE=true)。
+# legacy-snapshot は legacy_store.rs が include_str! で取り込むため build に必要。
 COPY src ./src
 COPY sqlx-data.json ./sqlx-data.json
+COPY migration/legacy-snapshot ./migration/legacy-snapshot
 ENV SQLX_OFFLINE=true
 RUN touch src/main.rs && cargo build --release --locked
 


### PR DESCRIPTION
## Summary

PR #29 で `legacy_store.rs` に `include_str!("../migration/legacy-snapshot/...")` を入れたが、Dockerfile が `migration/` を COPY していないため Docker build で fail。手元 `cargo test` は通る (host fs から読める) が、CI の release build inside Docker は落ちる。

## 根本原因

- 手元 `cargo test` だけで OK と判断したのが誤り。`include_str!` は build-time に file system 読みに行くため、Docker build context にも対象ファイルが必要。
- 結果: PR #29 merge 後の deploy workflow (run 27698221928) が builder 7/7 で `couldn't read 'src/../migration/legacy-snapshot/submissions.json': No such file or directory` で失敗。

## 修正

Dockerfile に 1 行 `COPY migration/legacy-snapshot ./migration/legacy-snapshot` を追加。`.dockerignore` は `migration/` を除外していないので build context には既に含まれている。

## Test plan

- [ ] CI (deploy workflow) で builder 7/7 が通る
- [ ] staging に新 image が配備され `/legacy/submissions?page=1` が JSON を返す