### PR TITLE
chore(T006): set staging frontend host to qkjudge-stg.kisen.one

### DIFF
--- a/deploy/k3s/overlays/staging/kustomization.yaml
+++ b/deploy/k3s/overlays/staging/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
   - name: qkjudge-config
     behavior: merge
     literals:
-      - CORS_ALLOW_ORIGIN=https://dev.qkjudge.kisen.one
+      - CORS_ALLOW_ORIGIN=https://qkjudge-stg.kisen.one
 
 images:
   - name: ghcr.io/kisepichu/qkjudge

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -39,7 +39,7 @@ qkjudge サーバーは traP の NeoShowcase 上で、gitea `git.trap.jp/tqk/qkj
 | 項目                 | 決定                                                                                                                                                                           |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | オーケストレーション | k3s on leafeon。最初から prod / staging のマルチ環境 (旧 Showcase のブランチ別デプロイを踏襲)                                                                                  |
-| 環境マッピング       | `master`→prod (`qkjudge.kisen.one` / API `qkjudge-api.kisen.one`)、`dev`→staging (`dev.qkjudge.kisen.one` / `qkjudge-api-stg.kisen.one`)                                       |
+| 環境マッピング       | `master`→prod (`qkjudge.kisen.one` / API `qkjudge-api.kisen.one`)、`dev`→staging (`qkjudge-stg.kisen.one` / `qkjudge-api-stg.kisen.one`、Universal SSL の 1 階層制約に合わせる) |
 | コンテナレジストリ   | GHCR (`ghcr.io/kisepichu/qkjudge`)                                                                                                                                             |
 | デプロイ反映         | leafeon 上のセルフホスト GitHub Actions Runner が `kubectl` 適用 (k3s API を外部公開しない)。**セキュリティ堅牢化必須**。GitOps(Argo/Flux) は将来移行                          |
 | 公開                 | cloudflared を k3s 内 Deployment として動かし、tunnel ingress 設定も k3s マニフェストで管理する (鯖機を直接設定せず pull+反映で完結)。DNS は Cloudflare に CNAME               |
@@ -97,7 +97,7 @@ frontend: GitHub Pages (kisen.one 独自ドメイン) — k3s 外
 | `http_proxy: 8080`                                                 | Dockerfile `EXPOSE 8080` / Service (TASK-003)                  |
 | `https: on`                                                        | cloudflared + Ingress (TASK-003)                               |
 | `use_mariadb: true`                                                | compose の `mariadb` サービス / k3s StatefulSet (TASK-003)     |
-| `branch.dev.cname: dev_tqk_qkjudge.trap.games`                     | `dev`→`dev.qkjudge.kisen.one` (上記「決定事項」)               |
+| `branch.dev.cname: dev_tqk_qkjudge.trap.games`                     | `dev`→`qkjudge-stg.kisen.one` (上記「決定事項」)               |
 
 problems リポジトリの取得元は旧 `tqkoh/qkjudge-problems` から `kisepichu/qkjudge-problems` に更新した。
 

--- a/tasks/doing/TASK-006-frontend-cutover.md
+++ b/tasks/doing/TASK-006-frontend-cutover.md
@@ -21,7 +21,8 @@
   なので `SameSite=Lax; Secure` + `withCredentials` で問題なく動く。Cookie は **API ホスト上で host-only に完結**し
   (Domain 属性で親に広げない)、**HTTPS / `Secure` 前提**。これらが満たされることを確認する。
 - **ドメイン/公開**: GitHub Pages の独自ドメインを `qkjudge.kisen.one` に (CNAME ファイル + Cloudflare DNS)。
-  staging フロントは `dev.qkjudge.kisen.one` (別 Pages か k3s 配信かは TASK-003/004 と整合)。
+  staging フロントは `qkjudge-stg.kisen.one` (Cloudflare Universal SSL は 1 階層サブドメインのみカバーするため
+  `dev.qkjudge.kisen.one` のような 2 階層は使わず、API 側の `qkjudge-api-stg.kisen.one` と命名規則を揃える)。
 - **再登録告知**: トップページに「旧 judge.tqk.blue のアカウントは移行されていません。再登録してください」を表示。
 - **legacy 表示**: 提出一覧で新提出が尽きた後に TASK-005 の `/legacy/*` を表示、author に `[legacy]` prefix。
   旧サーバー CORS は `judge.tqk.blue` 限定のため**ブラウザ直叩きはしない** (必ず新サーバーの legacy
@@ -35,7 +36,7 @@
 - [ ] `.env`/`.env.development` の `VITE_API_URL` を新 API に更新
 - [ ] ログイン/whoami/submit/submissions が新 API + `SameSite=Lax` cookie で動く
 ### ドメイン公開
-- [ ] CNAME + Cloudflare DNS で `qkjudge.kisen.one` 公開、(可能なら) `dev.` も
+- [ ] CNAME + Cloudflare DNS で `qkjudge.kisen.one` 公開、staging 用 `qkjudge-stg.kisen.one` も
 ### UI 変更
 - [ ] トップに再登録告知
 - [ ] 提出一覧末尾に legacy 表示 (`[legacy]` prefix、TASK-005 と整合)
@@ -51,3 +52,9 @@
 ## 作業ログ
 
 - 2026-05-31: タスク生成。
+- 2026-06-18: Phase A 着手。staging frontend host を `qkjudge-stg.kisen.one` に確定
+  (Universal SSL の 1 階層制約のため `dev.qkjudge.kisen.one` は使わず、`qkjudge-api-stg.kisen.one`
+  と命名を揃える)。`deploy/k3s/overlays/staging/kustomization.yaml` の `CORS_ALLOW_ORIGIN`
+  を新ホストに更新。prod overlay は `https://qkjudge.kisen.one` で既に正。
+  Cloudflare DNS は別途手動で CNAME `qkjudge-stg.kisen.one` / `qkjudge.kisen.one` →
+  `kisepichu.github.io` を追加する (agent では触らない)。


### PR DESCRIPTION
## Summary
- TASK-006 Phase A. Staging フロントの公開先を `qkjudge-stg.kisen.one` に確定し、staging API の `CORS_ALLOW_ORIGIN` をそのオリジンに更新する。
- 元設計の `dev.qkjudge.kisen.one` は 2 階層になり Cloudflare Universal SSL (`*.kisen.one`、1 階層のみ) でカバーできないため、API 側の改名 (`qkjudge-api-stg.kisen.one`、PR #23) と命名規則を揃えて 1 階層に寄せる。
- prod overlay は元から `https://qkjudge.kisen.one` を指しており変更不要 (このコミットでは触らない)。
- TASK-006 を `tasks/doing/` に移動し、`docs/MIGRATION.md` の決定事項テーブル / クリーンアップテーブルからも旧 staging host 名を消した。

## DNS (out-of-band; agent では触らない)
Cloudflare で以下の CNAME を追加する想定:
- `qkjudge.kisen.one` → `kisepichu.github.io` (prod / TASK-006 Phase B 着手前でよい)
- `qkjudge-stg.kisen.one` → `kisepichu.github.io` (staging)

## Test plan
- [ ] このマージで dev → staging deploy がトリガされ、`qkjudge-api-stg.kisen.one` の `CORS_ALLOW_ORIGIN` が新 origin になる
- [ ] (Phase B 後) qkjudge-UI repo を `qkjudge-stg.kisen.one` で配信開始した後、`Origin: https://qkjudge-stg.kisen.one` での `OPTIONS /signup` / `POST /signup` が `Access-Control-Allow-Origin` を返すこと
- [ ] prod overlay は無変更なので prod デプロイには影響しないこと (kustomize build 差分なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)